### PR TITLE
Issue 2 filebrowser.theme.inc uses deprecated function create_function() 

### DIFF
--- a/filebrowser.theme.inc
+++ b/filebrowser.theme.inc
@@ -259,7 +259,7 @@ function theme_dir_listing_list_view($node) {
         if ($table_sort['sort'] == 'asc') {
           $just_folders = array_reverse($just_folders, TRUE);
         }
-        usort($just_folders, $sorter);
+        usort($just_files, $sorter);
         if ($table_sort['sort'] == 'asc') {
           $just_files = array_reverse($just_files, TRUE);
         }

--- a/filebrowser.theme.inc
+++ b/filebrowser.theme.inc
@@ -127,7 +127,7 @@ function theme_dir_listing_list_view($node) {
             $visible_columns[$column_name] = TRUE;
             $unsorted_rows[$file_name][FILEBROWSER_DATA_NAME_ICON] = array(
                 'data' => _filebrowser_thumbnails_generate($node, $data),
-                'style' => 'width:1%;'
+                'class' => 'icon'
             );
             break;
 
@@ -236,26 +236,30 @@ function theme_dir_listing_list_view($node) {
       $field = $table_sort['sql'];
       $columns = _filebrowser_externals('metadata_info');
       if (isset($columns[$table_sort['sql']]) && isset($columns[$table_sort['sql']]['sortable']) && $columns[$table_sort['sql']]['sortable']) {
+        $sorter = null;        
         switch ($columns[$table_sort['sql']]['type']) {
           case 'integer' :
-            $code = '$a=isset($a["' . $field . '"])?$a["' . $field . '"]:0;';
-            $code .= '$b=isset($b["' . $field . '"])?$b["' . $field . '"]:0;';
-            $code .= 'return $a-$b;';
+            $sorter = function ($a, $b) use ($field) {
+              $a = isset($a->$field) ? $a->$field : 0;
+              $b = isset($b->$field) ? $b->$field : 0;
+              return $a-$b;
+            };
             break;
 
           case 'string' :
-            $code = '$a=isset($a["' . $field . '"])?$a["' . $field . '"]:"";';
-            $code .= '$b=isset($b["' . $field . '"])?$b["' . $field . '"]:"";';
-            $code .= 'return -strcmp(strtolower($a),strtolower($b));';
+            $sorter = function ($a, $b) use ($field) {
+              $a = isset($a->$field) ? $a->$field : '';
+              $b = isset($b->$field) ? $b->$field : '';
+              return -strcmp(backdrop_strtolower($a), backdrop_strtolower($b));
+            };
             break;
 
         }
-        $sorter = create_function('$a,$b', $code);
         usort($just_folders, $sorter);
         if ($table_sort['sort'] == 'asc') {
           $just_folders = array_reverse($just_folders, TRUE);
         }
-        usort($just_files, create_function('$a,$b', $code));
+        usort($just_folders, $sorter);
         if ($table_sort['sort'] == 'asc') {
           $just_files = array_reverse($just_files, TRUE);
         }


### PR DESCRIPTION
Remove create_function();
Replace inline style for file/folder icon with class 'icon'

This fixes issue 2 related to deprecated php function create_function for php later than 7.2.
Taken from patches provided for Drupal version of the module and adapted for Backdrop - see:
https://www.drupal.org/project/filebrowser/issues/3061756 

Also addresses separate issue related to display of file/folder icons: containing table cell (td) had width set as % and this is replaced by a class added to the cell.